### PR TITLE
Concept for CoT in LM-Eval

### DIFF
--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -797,14 +797,9 @@ def ChainOfThoughtPromptingTask(PromptSourceTask):
     def chain_of_thought_docs(self) -> datasets.Dataset:
         """
         Returns:
-            A dataset of training documents.
+            A subset of samples with chain-of-thought examples..
         """
-        return datasets.Dataset.from_dict({
-            0: "Sample 0",
-            1: "Sample 1",
-            2: "Sample 2",
-            3: "Sample 3",
-            })
+        raise NotImplementedError("Needs a set of examples")
 
     def fewshot_docs(self) -> datasets.Dataset:
         """Returns the `dataset` split that the few-shot examples should be sample

--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -785,3 +785,31 @@ class PerplexityTask(PromptSourceTask):
         return {
             "prompt_name": None,
         }
+
+
+def ChainOfThoughtPromptingTask(PromptSourceTask):
+
+    @abstractmethod
+    def has_chain_of_thought_docs(self):
+        """Whether the task has a chain-of-thought set"""
+        return True
+
+    def chain_of_thought_docs(self) -> datasets.Dataset:
+        """
+        Returns:
+            A dataset of training documents.
+        """
+        return datasets.Dataset.from_dict({
+            0: "Sample 0",
+            1: "Sample 1",
+            2: "Sample 2",
+            3: "Sample 3",
+            })
+
+    def fewshot_docs(self) -> datasets.Dataset:
+        """Returns the `dataset` split that the few-shot examples should be sample
+        from. This prioritizes the `train_docs` split as the few-shot example
+        source, then `validation_docs`, and lastly `test_docs`.
+        """
+        if self.has_chain_of_thought_docs():
+            return self.chain_of_thought_docs()

--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -787,9 +787,8 @@ class PerplexityTask(PromptSourceTask):
         }
 
 
-def ChainOfThoughtPromptingTask(PromptSourceTask):
+class ChainOfThoughtPromptingTask(PromptSourceTask):
 
-    @abstractmethod
     def has_chain_of_thought_docs(self):
         """Whether the task has a chain-of-thought set"""
         return True
@@ -808,3 +807,20 @@ def ChainOfThoughtPromptingTask(PromptSourceTask):
         """
         if self.has_chain_of_thought_docs():
             return self.chain_of_thought_docs()
+
+    def doc_to_text(self, doc: dict) -> str:
+        if "cot" in doc:
+            text = doc['cot']
+        else:
+            text, _ = self.prompt_template.apply(doc)
+        
+        return text
+
+    def doc_to_target(self, doc: dict) -> str:
+        if "cot" in doc:
+            text = " "
+        else:
+            text, _ = self.prompt_template.apply(doc)
+        
+        return text
+        

--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -90,6 +90,7 @@ TASK_REGISTRY = {
     "gem_xsum_challenge_test_covid": gem_xsum.GEMXSUMChallgeTestCovid,
     # gsm8k
     "gsm8k": gsm8k.GradeSchoolMath8K,
+    # "gsm8k_cot": gsm8k.GradeSchoolMath8KCoT,
     # LAMA
     "lama-trex": lama.Trex,
     "lama-squad": lama.Squad,

--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -90,7 +90,7 @@ TASK_REGISTRY = {
     "gem_xsum_challenge_test_covid": gem_xsum.GEMXSUMChallgeTestCovid,
     # gsm8k
     "gsm8k": gsm8k.GradeSchoolMath8K,
-    # "gsm8k_cot": gsm8k.GradeSchoolMath8KCoT,
+    "gsm8k_cot": gsm8k.GradeSchoolMath8KCoT,
     # LAMA
     "lama-trex": lama.Trex,
     "lama-squad": lama.Squad,

--- a/lm_eval/tasks/gsm8k.py
+++ b/lm_eval/tasks/gsm8k.py
@@ -19,7 +19,7 @@ Homepage: https://github.com/openai/grade-school-math
 import inspect
 import re
 from pathlib import Path
-from lm_eval.api.task import PromptSourceTask
+from lm_eval.api.task import PromptSourceTask, ChainOfThoughtPromptingTask
 from lm_eval.api.request import rf
 from lm_eval.api.metric import mean
 
@@ -133,3 +133,8 @@ class GradeSchoolMath8K(PromptSourceTask):
 
     def max_generation_length(self):
         return 192
+
+
+class GradeSchoolMath8KCoT(ChainOfThoughtPromptingTask):
+    # Still WIP
+    pass

--- a/lm_eval/tasks/gsm8k.py
+++ b/lm_eval/tasks/gsm8k.py
@@ -18,6 +18,7 @@ Homepage: https://github.com/openai/grade-school-math
 """
 import inspect
 import re
+import datasets
 from pathlib import Path
 from lm_eval.api.task import PromptSourceTask, ChainOfThoughtPromptingTask
 from lm_eval.api.request import rf
@@ -136,5 +137,19 @@ class GradeSchoolMath8K(PromptSourceTask):
 
 
 class GradeSchoolMath8KCoT(ChainOfThoughtPromptingTask):
-    # Still WIP
-    pass
+
+    def chain_of_thought_docs(self) -> datasets.Dataset:
+        """
+        Returns:
+            A dataset of training documents.
+        """
+        return datasets.Dataset.from_dict({
+            0: "Q: There are 15 trees in the grove. Grove workers will plant trees in the grove today. After they are done, there will be 21 trees. How many trees did the grove workers plant today?\n\nA: There are 15 trees originally. Then there were 21 trees after some more were planted. So there must have been 21 - 15 = 6. The answer is 6.",
+            1: "Q: If there are 3 cars in the parking lot and 2 more cars arrive, how many cars are in the parking lot?\n\nA: There are originally 3 cars. 2 more cars arrive. 3 + 2 = 5. The answer is 5.",
+            2: "Q: Leah had 32 chocolates and her sister had 42. If they ate 35, how many pieces do they have left in total?\n\nA: Originally, Leah had 32 chocolates. Her sister had 42. So in total they had 32 + 42 = 74. After eating 35, they had 74 - 35 = 39. The answer is 39.",
+            3: "Q: Jason had 20 lollipops. He gave Denny some lollipops. Now Jason has 12 lollipops. How many lollipops did Jason give to Denny?\n\nA: Jason started with 20 lollipops. Then he had 12 after giving some to Denny. So he gave Denny 20 - 12 = 8. The answer is 8.",
+            4: "Q: Shawn has five toys. For Christmas, he got two toys each from his mom and dad. How many toys does he have now?\n\nA: Shawn started with 5 toys. If he got 2 toys each from his mom and dad, then that is 4 more toys. 5 + 4 = 9. The answer is 9.",
+            5: "Q: There were nine computers in the server room. Five more computers were installed each day, from monday to thursday. How many computers are now in the server room?\n\nA: There were originally 9 computers. For each of 4 days, 5 more computers were added. So 5 * 4 = 20 computers were added. 9 + 20 is 29. The answer is 29.",
+            6: "Q: Michael had 58 golf balls. On tuesday, he lost 23 golf balls. On wednesday, he lost 2 more. How many golf balls did he have at the end of wednesday?\n\nA: Michael started with 58 golf balls. After losing 23 on tuesday, he had 58 - 23 = 35. After losing 2 more, he had 35 - 2 = 33 golf balls. The answer is 33.",
+            7: "Q: Olivia has $23. She bought five bagels for $3 each. How much money does she have left?\n\nA: Olivia had 23 dollars. 5 bagels for 3 dollars each will be 5 x 3 = 15 dollars. So she has 23 - 15 dollars left. 23 - 15 is 8. The answer is 8."
+        })


### PR DESCRIPTION
A proposed method to host CoT Samples in LM-Eval.
The main ideas:

1. `ChainOfThoughtPromptingTask` that inherits `PromptSourceTask` has the function `chain_of_thought_docs` where chain-of-though examples can be stored for each dataset implementation.
2. The function `fewshot_docs` takes the examples from `chain_of_thought_docs` instead of any dataset splits.